### PR TITLE
Catch-22: Hack to publish the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ jobs:
   - stage: test
     script: sbt +test
   - stage: release
-    script: sbt ci-release-sonatype
+    script: sbt \"set ThisBuild/version := \"1.1.13\"\" publishSigned sonatypeBundleRelease
+    #  - stage: release
+    #script: sbt ci-release-sonatype
 
 before_cache:
 - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.8")
+//addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.8")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")


### PR DESCRIPTION
We got ourselves in a catch-22 situation. In order to publish
`ci-release-early` plugin we have to have a new version of sonatype
pluging in place. But since this plugin uses itself to publish, it can't
publish itself.

Classic.