### PR TITLE
Revert previous workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ jobs:
   - stage: test
     script: sbt +test
   - stage: release
-    script: sbt \"set ThisBuild/version := \"1.1.13\"\" publishSigned sonatypeBundleRelease
-    #  - stage: release
-    #script: sbt ci-release-sonatype
+    script: sbt ci-release-sonatype
 
 before_cache:
 - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   - stage: test
     script: sbt +test
   - stage: release
-    script: sbt "set ThisBuild/version := \"1.1.13\"" publishSigned sonatypeBundleRelease
+    script: sbt \"set ThisBuild/version := \"1.1.13\"\" publishSigned sonatypeBundleRelease
     #  - stage: release
     #script: sbt ci-release-sonatype
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-//addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.8")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.8")


### PR DESCRIPTION
Sonatype is failing really bad and upgrading the `sbt-sonatype` dependency won't help here.
So we might as well go back to the previous way we deploy the plugin.