### PR TITLE
Allow setting which part of the version to increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ private-key.pem
 /.bsp
 /.bsp
 /gnupg-*
+
+# Metals
+.bloop
+.metals
+metals.sbt
+
+# VSCode
+.vscode

--- a/project/dependencies.sbt
+++ b/project/dependencies.sbt
@@ -1,0 +1,6 @@
+libraryDependencies += "org.eclipse.jgit"     % "org.eclipse.jgit" % "5.4.3.201909031940-r"
+libraryDependencies += "com.michaelpollmeier" % "versionsort"      % "1.0.1"
+
+// For using the plugin in its own build
+unmanagedSourceDirectories in Compile +=
+  baseDirectory.in(ThisBuild).value.getParentFile / "src" / "main" / "scala"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.13")
+addSbtPlugin("com.michaelpollmeier" % "sbt-git" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")

--- a/readme.md
+++ b/readme.md
@@ -15,18 +15,20 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 <!-- markdown-toc --maxdepth 1 --no-firsth1 readme.md -->
 
 ## Features
-* detects last version from git tags (e.g. `v1.0.0`), and automatically tags and releases the next version as `v1.0.1`
-* no snapshots, no manual tagging
-* automatically performs a cross-release if your build has multiple scala versions configured
-* uses sbt-sonatype's fast new `sonatypeBundleRelease`
-* use `ciRelease` for your in-house setup (e.g. jenkins/artifactory/nexus etc), very easy to configure
-* use `ciReleaseSonatype` for your open source actions/sonatype/maven-central setup, a little more involved to configure
-* easy to test locally (faster turnaround than debugging on ci)
-* verifies that your build does not depend on any snapshot dependencies
+
+- detects last version from git tags (e.g. `v1.0.0`), and automatically tags and releases the next version as `v1.0.1`
+- no snapshots, no manual tagging
+- automatically performs a cross-release if your build has multiple scala versions configured
+- uses sbt-sonatype's fast new `sonatypeBundleRelease`
+- use `ciRelease` for your in-house setup (e.g. jenkins/artifactory/nexus etc), very easy to configure
+- use `ciReleaseSonatype` for your open source actions/sonatype/maven-central setup, a little more involved to configure
+- easy to test locally (faster turnaround than debugging on ci)
+- verifies that your build does not depend on any snapshot dependencies
 
 ## Installation
 
 Add the dependency in your `projects/plugins.sbt`:
+
 ```
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % <version>)
 ```
@@ -34,54 +36,77 @@ addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % <version>)
 Latest version: [![Scaladex](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)
 
 Enable sbt-git (automatically brought in as a plugin dependency) in your `build.sbt`, this will automatically set the `version` based on your git repo (e.g. the git tag, or as a fallback the commit sha)
+
 ```
 enablePlugins(GitVersioning)
 ```
 
-If you don't have any previous versions tagged in git, now is the time to choose your versioning scheme. To do so simply tag your current commit with the version you want: 
+If you don't have any previous versions tagged in git, now is the time to choose your versioning scheme. To do so simply tag your current commit with the version you want:
+
 ```
 git tag v0.0.1
 ```
+
 N.b. other versioning schemes like `v1`, `v0.1`, `v0.0.0.1` will work as well, they only must start with `v`
-Ensure you don't have any uncommitted local changes and run `sbt "show version"` to verify that the git version plugin works. 
+Ensure you don't have any uncommitted local changes and run `sbt "show version"` to verify that the git version plugin works.
 
 ## Configuration for an in-house repository (e.g. jenkins/artifactory)
+
 Make sure the `publishTo` key in your `built.sbt` points to your repository:
+
 ```
 ThisBuild/publishTo := Some("releases" at "https://shiftleft.jfrog.io/shiftleft/libs-release-local")
 ```
+
 If it's a multi-project build you may need to prefix it with `ThisBuild/` in your root build.sbt.
 
 Commit (and push) any local changes, then let's check that everything works - you can do this locally.
-1) auto-tagging: determines last released version based on git tags and creates a new one:
+
+1. auto-tagging: determines last released version based on git tags and creates a new one:
+
 ```
 sbt ciReleaseTagNextVersion
 ```
 
-2) Publish a release
+2. Publish a release
+
 ```
 sbt ciRelease
 ```
 
 If that all worked, just configure the two commands `ciReleaseTagNextVersion ciRelease` at the end of your build pipeline on your CI server. A complete command would e.g. be:
+
 ```
 sbt clean test ciReleaseTagNextVersion ciRelease
 ```
 
-Cross builds (for multiple scala versions) work seamlessly (the plugin just calls `+publishSigned`). 
+Cross builds (for multiple scala versions) work seamlessly (the plugin just calls `+publishSigned`).
+
+## Increasing different parts of the version
+
+By default this plugin will increase the "patch" part (v1.0.**0**) of a version (if it is present) but this functionality can be modified using the following arguments when calling `ciReleaseTagNextVersion`, notice that all of them are mutually exclusive:
+
+- `--increase-major`: adding this argument will make the plugin update the major version. This means `v1` will become `v2`, `v1.2` will become `v2.0` and `v1.2.3` will become `v2.0.0`.
+- `--increase-minor`: adding this argument will make the plugin update the minor version. This means `v1` will become `v1.1`, `v1.2` will become `v1.3` and `v1.2.3` will become `v1.3.0`.
+- `--increase-patch`: adding this argument will make the plugin update the patch version. This means `v1` will become `v1.0.1`, `v1.2` will become `v1.2.1` and `v1.2.3` will become `v1.2.4`.
 
 ## Configuration for sonatype (maven central) via github actions
-Sonatype (which syncs to maven central) imposes additional constraints on the published artifacts, so the setup becomes a little more involved. These steps assume you're using github actions, but it'd be similar on other build servers. 
+
+Sonatype (which syncs to maven central) imposes additional constraints on the published artifacts, so the setup becomes a little more involved. These steps assume you're using github actions, but it'd be similar on other build servers.
 
 ### Sonatype account
-If you don't have a sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one. 
+
+If you don't have a sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one.
 It's advisable (yet optional) to create a user token, which guises your actual user/password.
 
 ### build.sbt
-Make sure `build.sbt` *does not* define any of the following settings:
+
+Make sure `build.sbt` _does not_ define any of the following settings:
+
 - `version`
 
-Ensure the following settings *are* defined in your `build.sbt`:
+Ensure the following settings _are_ defined in your `build.sbt`:
+
 - `name`
 - `organization`: must match your sonatype account
 - `licenses`
@@ -94,9 +119,11 @@ Example: https://github.com/mpollmeier/sbt-ci-release-early-usage/blob/master/bu
 For a multi-project build, you can define those settings in your root `build.sbt` and prefix them with `ThisBuild/`, e.g. `ThisBuild/publishTo := sonatypePublishToBundle.value`
 
 ### gitignore
+
 `echo '/gnupg-*' >> .gitignore`
 
 ### gpg keys
+
 Sonatype requires all artifacts to be signed. Since it doesn't matter which key it's signed with, and we need to share the private key with the build server (e.g. github actions), we will simply create a new one specifically for this project:
 
 ```
@@ -105,7 +132,7 @@ gpg --gen-key
 
 - For real name, use "$PROJECT_NAME bot", e.g. `sbt-ci-release-early bot`
 - For email, use your own email address
-- Passphrase: leave empty, i.e. no passphrase. It will warn you that it's not a good idea, but this is just a pro forma key for sonatype. You'll only share the key with github, and if it had a passphrase you'd have to share that with github as well, anyway. Private key passphrases gave me a lot of headaches across different gpg versions, so I decided to advise against them. If you like you can encrypt your private key, e.g. with gpg or openssl. 
+- Passphrase: leave empty, i.e. no passphrase. It will warn you that it's not a good idea, but this is just a pro forma key for sonatype. You'll only share the key with github, and if it had a passphrase you'd have to share that with github as well, anyway. Private key passphrases gave me a lot of headaches across different gpg versions, so I decided to advise against them. If you like you can encrypt your private key, e.g. with gpg or openssl.
 
 At the end you'll see output like this
 
@@ -123,6 +150,7 @@ export LONG_ID=499FD7755EC30DDAF43089355E00EC8C822C6A2A
 ```
 
 Optional: if you would like to make the key never expire:
+
 ```bash
 gpg --edit-key $LONG_ID
 expire #follow prompt
@@ -138,14 +166,15 @@ gpg --keyserver keyserver.ubuntu.com --send-keys $LONG_ID
 ```
 
 ### Secrets to share with Github actions
-So that github actions can release on your behalf, we need to share some secret via environment variables in `Settings -> Secrets`. You can either do that for your project or an entire organization. 
+
+So that github actions can release on your behalf, we need to share some secret via environment variables in `Settings -> Secrets`. You can either do that for your project or an entire organization.
 
 - `SONATYPE_USERNAME`: The username you use to log into
   https://oss.sonatype.org/. Alternatively, the name part of the user token if
   you generated one above.
 - `SONATYPE_PASSWORD`: The password you use to log into
   https://oss.sonatype.org/. Alternatively, the password part of the user token
-  if you generated one above. 
+  if you generated one above.
 - `PGP_SECRET`: The base64 encoded secret of your private key that you can export from the command line like here below
 
 ```
@@ -166,10 +195,11 @@ Your secrets settings should look like this:
 
 ### Github Actions Workflow
 
-The final step is to configure your github actions workflow. There's many ways to do this, but most builds can probably take the below setup as is. It configures two workflows: one for pull requests which only runs the tests, and one for master builds, which also releases a new version. 
-Both are configured with a cache to avoid downloading all your dependencies for every build. 
+The final step is to configure your github actions workflow. There's many ways to do this, but most builds can probably take the below setup as is. It configures two workflows: one for pull requests which only runs the tests, and one for master builds, which also releases a new version.
+Both are configured with a cache to avoid downloading all your dependencies for every build.
 
 <project_root>/.github/workflows/pr.yml
+
 ```yml
 name: pr
 on: pull_request
@@ -191,6 +221,7 @@ jobs:
 ```
 
 <project_root>/.github/workflows/release.yml
+
 ```yml
 name: release
 on:
@@ -223,16 +254,18 @@ jobs:
 
 If you want to customize those: the syntax is [documented here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions).
 
-Optional: add a [status badge](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge) to your readme (replace OWNER and REPOSITORY): 
+Optional: add a [status badge](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge) to your readme (replace OWNER and REPOSITORY):
+
 ```
 [![Build Status](https://github.com/<OWNER>/<REPOSITORY>/workflows/release/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions?query=workflow%3Arelease)
 ```
 
-
 That's all. Here's a demo repo: https://github.com/mpollmeier/sbt-ci-release-early-usage
 
 ## Dependencies
+
 By installing `sbt-ci-release-early` the following sbt plugins are also brought in:
+
 - [sbt-git](https://github.com/sbt/sbt-git/): sets the project version based on the git tag
 - [sbt-pgp](https://github.com/sbt/sbt-pgp): signs the artifacts before publishing
 - [sbt-sonatype](https://github.com/xerial/sbt-sonatype): publishes your artifacts to Sonatype
@@ -241,26 +274,30 @@ By installing `sbt-ci-release-early` the following sbt plugins are also brought 
 
 ### How can determine the latest released version?
 
-Other than manually looking at sonatype/maven central or git tags, you can use the following snippet that remotely gets the git tags that start with `v` and have (in this version) three decimals separated by `.`, and returns the highest version. 
+Other than manually looking at sonatype/maven central or git tags, you can use the following snippet that remotely gets the git tags that start with `v` and have (in this version) three decimals separated by `.`, and returns the highest version.
 
 ```
 git ls-remote --tags $REPO | awk -F"/" '{print $3}' | grep '^v[0-9]*\.[0-9]*\.[0-9]*' | grep -v {} | sort --version-sort | tail -n1
 ```
 
 ### My sonatype staging repos seems to be in a broken state
+
 When a build is e.g. interrupted, or didn't satisfy the sonatype requirements for publishing, it is likely that these artifacts are still lying around in the sonatype staging area. You can log into https://oss.sonatype.org/ and clean it up, or just do it from within sbt, locally on your machine:
 
-* `sonatypeStagingRepositoryProfiles` // lists staging repo ids
-* `sonatypeDrop [id]`
+- `sonatypeStagingRepositoryProfiles` // lists staging repo ids
+- `sonatypeDrop [id]`
 
 ### Why not just use SNAPSHOT dependencies instead?
-SNAPSHOT dependencies are evil because they:
-* are mutable, i.e. your builds aren't reproducible
-* slow down your build, because sbt has to check for updates all the time
-* involve (sometimes multiple layers) of caches, which tend to break and add complexity if you try to debug a problem
 
-### How do I release a specific version? 
-To keep things simple I decided to not add that feature to this plugin. 
+SNAPSHOT dependencies are evil because they:
+
+- are mutable, i.e. your builds aren't reproducible
+- slow down your build, because sbt has to check for updates all the time
+- involve (sometimes multiple layers) of caches, which tend to break and add complexity if you try to debug a problem
+
+### How do I release a specific version?
+
+To keep things simple I decided to not add that feature to this plugin.
 If you want to release a specific version you have to do that yourself:
 
 ```
@@ -273,7 +310,8 @@ sonatypeBundleRelease
 git tag v1.2.3
 git push origin v1.2.3
 ```
-Note to future self: this would have added complexity because to trigger it we would rely on git tags, and we need a foolproof way to check if a given tag has already been released. My intial thought was to tag anything released with `_released_1.0.1_`, but it was getting quite complicated for handling an edge case. 
+
+Note to future self: this would have added complexity because to trigger it we would rely on git tags, and we need a foolproof way to check if a given tag has already been released. My intial thought was to tag anything released with `_released_1.0.1_`, but it was getting quite complicated for handling an edge case.
 
 ### How do I disable publishing in certain projects?
 
@@ -284,7 +322,8 @@ publish/skip := true
 ```
 
 ### What if my build contains subprojects?
-If the build defines a dependency on the subproject (e.g. `dependsOn(subProjectName)`) then it's automatically included in the release. 
+
+If the build defines a dependency on the subproject (e.g. `dependsOn(subProjectName)`) then it's automatically included in the release.
 Otherwise you can just append `subProjectName/publish` to your build pipeline, the version is already set for you :)
 
 ### Can I use my releases immediately?
@@ -304,7 +343,7 @@ Yes. This plugin is published with a previous version of itself :)
 There exist great alternatives to sbt-ci-release-early that may work better for your setup.
 
 - [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release):
-  The most popular release plugin I believe. Main difference: releases versions that you previously tagged in git (rather than automatically tagging every build). 
-  This plugin is essentially a fork of sbt-ci-release, they share most traits. 
+  The most popular release plugin I believe. Main difference: releases versions that you previously tagged in git (rather than automatically tagging every build).
+  This plugin is essentially a fork of sbt-ci-release, they share most traits.
 - [sbt-release-early](https://github.com/scalacenter/sbt-release-early):
 - [sbt-rig](https://github.com/Verizon/sbt-rig)

--- a/src/main/scala/ci/release/early/Plugin.scala
+++ b/src/main/scala/ci/release/early/Plugin.scala
@@ -27,14 +27,27 @@ object Plugin extends AutoPlugin {
     /* I tried to define these commands as tasks, but had the following errors:
      * - didn't know how to update the version within the task
      * - didn't figure out how to automatically cross-build without lot's of extra code
-    */
-    commands += Command.command("ciReleaseTagNextVersion") { state =>
-      val tag = Utils.determineAndTagTargetVersion(state.log.info(_), Increment.Patch).tag
-      Utils.push(tag, state.log.info(_))
-      state.log.info("reloading sbt so that sbt-git will set the `version`" +
-        s" setting based on the git tag ($tag)")
-      "verifyNoSnapshotDependencies" :: "reload" :: state
-      },
+     */
+    commands += Command.args("ciReleaseTagNextVersion", "--increase-major | --increase-minor | --increase-patch") { (state, args) =>
+      val maybeIncrement = args match {
+        case Seq("--increase-patch") | Nil => Some(Increment.Patch)
+        case Seq("--increase-minor")       => Some(Increment.Minor)
+        case Seq("--increase-major")       => Some(Increment.Major)
+        case _                             => None
+      }
+
+      maybeIncrement.map { increment =>
+        val tag = Utils.determineAndTagTargetVersion(state.log.info(_), increment).tag
+        Utils.push(tag, state.log.info(_))
+        state.log.info("reloading sbt so that sbt-git will set the `version`" +
+          s" setting based on the git tag ($tag)")
+        "verifyNoSnapshotDependencies" :: "reload" :: state
+      }.getOrElse {
+        state.log.error(s"Invalid argument/s `${args.mkString(" ")}`")
+        state.log.error("The only arguments allowed are `--increase-major`, `--increase-minor` and `--increase-patch`")
+        state.fail
+      }
+    },
     commands += Command.command("ciRelease") { state =>
       state.log.info("Running ciRelease")
       "verifyNoSnapshotDependencies" :: "+publish" :: state

--- a/src/main/scala/ci/release/early/Plugin.scala
+++ b/src/main/scala/ci/release/early/Plugin.scala
@@ -29,7 +29,7 @@ object Plugin extends AutoPlugin {
      * - didn't figure out how to automatically cross-build without lot's of extra code
     */
     commands += Command.command("ciReleaseTagNextVersion") { state =>
-      val tag = Utils.determineAndTagTargetVersion(state.log.info(_)).tag
+      val tag = Utils.determineAndTagTargetVersion(state.log.info(_), Increment.Patch).tag
       Utils.push(tag, state.log.info(_))
       state.log.info("reloading sbt so that sbt-git will set the `version`" +
         s" setting based on the git tag ($tag)")

--- a/src/main/scala/ci/release/early/Plugin.scala
+++ b/src/main/scala/ci/release/early/Plugin.scala
@@ -29,19 +29,18 @@ object Plugin extends AutoPlugin {
      * - didn't figure out how to automatically cross-build without lot's of extra code
     */
     commands += Command.command("ciReleaseTagNextVersion") { state =>
-      def log(msg: String) = sLog.value.info(msg)
-      val tag = Utils.determineAndTagTargetVersion(log).tag
-      Utils.push(tag, log)
-      sLog.value.info("reloading sbt so that sbt-git will set the `version`" +
+      val tag = Utils.determineAndTagTargetVersion(state.log.info(_)).tag
+      Utils.push(tag, state.log.info(_))
+      state.log.info("reloading sbt so that sbt-git will set the `version`" +
         s" setting based on the git tag ($tag)")
       "verifyNoSnapshotDependencies" :: "reload" :: state
       },
     commands += Command.command("ciRelease") { state =>
-      sLog.value.info("Running ciRelease")
+      state.log.info("Running ciRelease")
       "verifyNoSnapshotDependencies" :: "+publish" :: state
     },
     commands += Command.command("ciReleaseSonatype") { state =>
-      sLog.value.info("Running ciReleaseSonatype")
+      state.log.info("Running ciReleaseSonatype")
       "verifyNoSnapshotDependencies" ::
         "clean" ::
         "sonatypeBundleClean" ::

--- a/src/test/scala/ci/release/early/UtilsTest.scala
+++ b/src/test/scala/ci/release/early/UtilsTest.scala
@@ -15,11 +15,21 @@ class UtilsTest extends WordSpec with Matchers {
   }
 
   "increment version" in {
-    Utils.incrementVersion("1") shouldBe "2"
-    Utils.incrementVersion("1.0") shouldBe "1.1"
-    Utils.incrementVersion("1.0.0") shouldBe "1.0.1"
-    Utils.incrementVersion("1.0.0-hotfix") shouldBe "1.0.1"
-    Utils.incrementVersion("1.0.0-hotfix2") shouldBe "1.0.1"
+    Utils.incrementVersion("1", Increment.Major) shouldBe "2"
+    Utils.incrementVersion("1", Increment.Minor) shouldBe "1.1"
+    Utils.incrementVersion("1", Increment.Patch) shouldBe "1.0.1"
+    Utils.incrementVersion("1.2", Increment.Major) shouldBe "2.0"
+    Utils.incrementVersion("1.2", Increment.Minor) shouldBe "1.3"
+    Utils.incrementVersion("1.2", Increment.Patch) shouldBe "1.2.1"
+    Utils.incrementVersion("1.3.1", Increment.Major) shouldBe "2.0.0"
+    Utils.incrementVersion("1.3.1", Increment.Minor) shouldBe "1.4.0"
+    Utils.incrementVersion("1.3.1", Increment.Patch) shouldBe "1.3.2"
+    Utils.incrementVersion("1.3.1-hotfix", Increment.Major) shouldBe "2.0.0"
+    Utils.incrementVersion("1.3.1-hotfix", Increment.Minor) shouldBe "1.4.0"
+    Utils.incrementVersion("1.3.1-hotfix", Increment.Patch) shouldBe "1.3.2"
+    Utils.incrementVersion("1.3.1-hotfix2", Increment.Major) shouldBe "2.0.0"
+    Utils.incrementVersion("1.3.1-hotfix2", Increment.Minor) shouldBe "1.4.0"
+    Utils.incrementVersion("1.3.1-hotfix2", Increment.Patch) shouldBe "1.3.2"
   }
 
   "interweave github token into repository url" in {


### PR DESCRIPTION
# What has been done in this PR?

The `ciReleaseTagNextVersion` has been converted to an "argument" command allowing the possibility to set which part of the version to update (major, minor or patch).

After this PR is merged this plugin will by default increase the "patch" part (v1.0.**0**) of a version but this functionality can be modified using the following arguments when calling `ciReleaseTagNextVersion`, notice that all of them are mutually exclusive:

- `--increase-major`: adding this argument will make the plugin update the major version. This means `v1` will become `v2`, `v1.2` will become `v2.0` and `v1.2.3` will become `v2.0.0`.
- `--increase-minor`: adding this argument will make the plugin update the minor version. This means `v1` will become `v1.1`, `v1.2` will become `v1.3` and `v1.2.3` will become `v1.3.0`.
- `--increase-patch`: adding this argument will make the plugin update the patch version. This means `v1` will become `v1.0.1`, `v1.2` will become `v1.2.1` and `v1.2.3` will become `v1.2.4`.


❗ Be aware that current implementation provokes a breaking change since the default functionality (no argument) will be to update the patch version (given that versions like `v1` will be updated to `v1.0.1`, if not using the `--increase-major` argument). One possibility would be to create a new major version of the plugin for this change, another possibility would be to make the argument mandatory, but that would provoke all build currently using the plugin to fail and deciding which approach to follow. I don't mind changing the PR if that's more desirable than creating a new major release.