### PR TITLE
Revert "Update org.eclipse.jgit to 6.0.0.202111291000-r"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sbtPlugin := true
 scalaVersion := "2.12.15"
 
 libraryDependencies ++= List(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "6.0.0.202111291000-r",
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.0.202109080827-r",
   "com.michaelpollmeier" % "versionsort" % "1.0.11",
   "org.scalatest" %% "scalatest" % "3.2.10" % Test)
 


### PR DESCRIPTION
Reverts ShiftLeftSecurity/sbt-ci-release-early#22

we don't want to lose java8 support