### PR TITLE
use sbt-dynver instead of sbt-git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= List(
   "com.michaelpollmeier" % "versionsort" % "1.0.11",
   "org.scalatest" %% "scalatest" % "3.2.12" % Test)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 

--- a/readme.md
+++ b/readme.md
@@ -33,12 +33,6 @@ addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % <version>)
 
 Latest version: [![Scaladex](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)
 
-Enable sbt-git (automatically brought in as a plugin dependency) in your `build.sbt`, this will automatically set the `version` based on your git repo (e.g. the git tag, or as a fallback the commit sha)
-```
-enablePlugins(GitVersioning)
-```
-Alternatively you can use (sbt-dynver)[https://github.com/dwijnand/sbt-dynver]. 
-
 If you don't have any previous versions tagged in git, now is the time to choose your versioning scheme. To do so simply tag your current commit with the version you want: 
 ```
 git tag v0.0.1
@@ -244,7 +238,7 @@ That's all. Here's a demo repo: https://github.com/mpollmeier/sbt-ci-release-ear
 
 ## Dependencies
 By installing `sbt-ci-release-early` the following sbt plugins are also brought in:
-- [sbt-git](https://github.com/sbt/sbt-git/): sets the project version based on the git tag
+- [sbt-dynver](https://github.com/sbt/sbt-dynver): sets the project version based on the git tag
 - [sbt-pgp](https://github.com/sbt/sbt-pgp): signs the artifacts before publishing
 - [sbt-sonatype](https://github.com/xerial/sbt-sonatype): publishes your artifacts to Sonatype
 

--- a/src/main/scala/ci/release/early/Plugin.scala
+++ b/src/main/scala/ci/release/early/Plugin.scala
@@ -1,7 +1,7 @@
 package ci.release.early
 
 import com.jsuereth.sbtpgp.SbtPgp
-import com.typesafe.sbt.GitPlugin
+import sbtdynver.DynVerPlugin
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Base64
@@ -19,7 +19,7 @@ object Plugin extends AutoPlugin {
   import autoImport._
 
   override def requires =
-    JvmPlugin && SbtPgp && GitPlugin && Sonatype
+    JvmPlugin && SbtPgp && DynVerPlugin && Sonatype
 
   override def globalSettings: Seq[Def.Setting[_]] = List(
     publishArtifact.in(Test) := false,
@@ -32,7 +32,7 @@ object Plugin extends AutoPlugin {
       def log(msg: String) = sLog.value.info(msg)
       val tag = Utils.determineAndTagTargetVersion(log).tag
       Utils.push(tag, log)
-      sLog.value.info("reloading sbt so that sbt-git will set the `version`" +
+      sLog.value.info("reloading sbt so that sbt-dynver will set the `version`" +
         s" setting based on the git tag ($tag)")
       "verifyNoSnapshotDependencies" :: "reload" :: state
       },


### PR DESCRIPTION
use sbt-dynver for it's nicer `1.2.3+2-hash` versions which preserve
ordering

fixes https://github.com/ShiftLeftSecurity/sbt-ci-release-early/issues/39