### PR TITLE
Update sbt-sonatype to 3.9.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= List(
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.18")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.19")
 
 homepage := Some(url("https://github.com/ShiftLeftSecurity/sbt-ci-release-early"))
 scmInfo := Some(ScmInfo(


### PR DESCRIPTION
carbon copy of
https://github.com/ShiftLeftSecurity/sbt-ci-release-early/pull/54 which
is/was stuck due to CI