### PR TITLE
improve scheduled release jobs (prevent duplicate releases)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,11 +7,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: sbt/setup-sbt@v1
-      - uses: actions/cache@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sudo apt update && sudo apt install -y gnupg
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
-      - run: sbt test ciReleaseTagNextVersion ciReleaseSonatype
+      - run: sbt test ciReleaseSkipIfAlreadyReleased ciReleaseTagNextVersion ciReleaseSonatype
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sbtPlugin := true
 scalaVersion := "2.12.20"
 
 libraryDependencies ++= List(
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r", // do not upgrade to 6.x unless you're willing to give up java 8 compatibility
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.3.202401111512-r", // do not upgrade to 6.x unless you're willing to give up java 8 compatibility
   "com.michaelpollmeier" % "versionsort" % "1.0.11",
   "org.scalatest" %% "scalatest" % "3.2.16" % Test)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.11

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ Otherwise you can just append `subProjectName/publish` to your build pipeline, t
 
 ### Can I use my releases immediately?
 
-As soon as sonatype "closes" the staging repository they are available on sonatype/releases and will be synchronized to maven central within ~10mins. If you want to use them immediately, add a sonatype resolver to the build that uses the released artifact:
+As soon as Sonatype "closes" the staging repository they become available on Sonatype/releases and will be synchronized to maven central within ~10mins. If you want to use them immediately, add a Sonatype resolver to the build that uses the released artifact:
 
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ gpg --keyserver keyserver.ubuntu.com --send-keys $LONG_ID
 So that Github Actions can release on your behalf, we need to share some secrets via environment variables with github actions. You can either do that for your project or an entire organization. 
 
 > [!NOTE]
-> As of June 2024 Sonatype requires you to log in with an access token, you can no longer use your regular username/password. 
+> As of June 2024, Sonatype requires you to log in with an access token, you can no longer use your regular username/password. 
   
 First you need to obtain a Sonatype username/password token: 
 - log into https://oss.sonatype.org

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,9 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 
 - [Features](#features)
 - [Installation](#installation)
-- [Configuration for an in-house repository (e.g. jenkins/artifactory)](#configuration-for-an-in-house-repository-eg-jenkinsartifactory)
-- [Configuration for sonatype (maven central) via github actions](#configuration-for-sonatype-maven-central-via-github-actions)
+- [Tasks defined by this plugin:](#tasks-defined-by-this-plugin)
+- [Setup for a custom repository (e.g. jfrog artifactory)](#setup-for-a-custom-repository-eg-jfrog-artifactory)
+- [Setup for sonatype / maven central](#setup-for-sonatype--maven-central)
 - [Dependencies](#dependencies)
 - [FAQ](#faq)
 - [Alternatives](#alternatives)

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,10 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 ## Features
 * detects last version from git tags (e.g. `v1.0.0`), and automatically tags and releases the next version as `v1.0.1`
 * no snapshots, no manual tagging
+* can be used in scheduled release jobs (can prevent duplicate releases if there haven't been any changes)
+* for both maven central and custom repositories (e.g. jenkins/artifactory/nexus etc)
+* verifies that your build does not depend on any snapshot dependencies to prevent problems early on
 * automatically performs a cross-release if your build has multiple scala versions configured
-* use `ciRelease` for your in-house setup (e.g. jenkins/artifactory/nexus etc), very easy to configure
-* use `ciReleaseSonatype` for your open source actions/sonatype/maven-central setup, a little more involved to configure
-* easy to test locally (faster turnaround than debugging on ci)
-* verifies that your build does not depend on any snapshot dependencies
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -25,20 +25,19 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 
 ## Installation
 
-Add the dependency in your `projects/plugins.sbt`:
+`projects/plugins.sbt`:
 ```
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "<version>")
 ```
-
-Latest version: [![Scaladex](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)
-
-If you don't have any previous versions tagged in git, the plugin will automatically create a `v0.1.0` tag for you. Alternatively you can manually create an initial version tag (e.g. `git tag v0.0.1`) and the plugin will take it from there. The same applies if you want to use a different versioning scheme, e.g. `v1`, `v0.1` or `v0.0.0.1`. All that matters is that they must start with `v` (by convention).
 
 ## Tasks defined by this plugin:
 * `ciReleaseSkipIfAlreadyReleased`: check if your current HEAD commit already has a version tag. Invoke this at the beginning if you want to skip the other tasks in that case, to avoid releasing the same commit multiple times. Useful e.g. for daily builds. Affects all other tasks below.
 * `ciReleaseTagNextVersion`: determine the next version (by finding the highest version and incrementing the last digit), then create a tag with that version and push it
 * `ciRelease`: publish to the configured repository
 * `ciReleaseSonatype`: publish to sonatype (using a [patched version](https://github.com/xerial/sbt-sonatype/pull/591) of [sbt-sonatype](https://github.com/xerial/sbt-sonatype))
+
+> [!NOTE]
+> If you don't have any previous versions tagged in git, the plugin will automatically create a `v0.1.0` tag for you. Alternatively you can manually create an initial version tag (e.g. `git tag v0.0.1`) and the plugin will take it from there. The same applies if you want to use a different versioning scheme, e.g. `v1`, `v0.1` or `v0.0.0.1`. All that matters is that they must start with `v` (by convention).
 
 ## Setup for a custom repository (e.g. jfrog artifactory)
 In your `build.sbt`:

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Example: https://github.com/mpollmeier/sbt-ci-release-early-usage/blob/master/bu
 For a multi-project build, you can define those settings in your root `build.sbt` and prefix them with `ThisBuild/`, e.g. `ThisBuild/publishTo := sonatypePublishToBundle.value`
 
 > [!WARNING]
-> By default, sbt-sonatype uses the legacy Sonatype repository `oss.sonatype.org`. If you created your after February 2021, you probably need to configure the new repository url via `sonatypeCredentialHost := "s01.oss.sonatype.org"`.
+> By default, sbt-sonatype uses the legacy Sonatype repository `oss.sonatype.org`. If you created yours after February 2021, you probably need to configure the new repository url via `sonatypeCredentialHost := "s01.oss.sonatype.org"`.
 
 ### gitignore
 `echo '/gnupg-*' >> .gitignore`

--- a/readme.md
+++ b/readme.md
@@ -21,16 +21,17 @@ addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "<version>")
 <!-- markdown-toc --maxdepth 1 --no-firsth1 readme.md | tail -n +3 -->
 - [Tasks](#tasks)
 - [Setup for a custom repository (e.g. jfrog artifactory)](#setup-for-a-custom-repository-eg-jfrog-artifactory)
-- [Setup for sonatype / maven central](#setup-for-sonatype--maven-central)
+- [Setup for Sonatype / Maven central](#setup-for-sonatype--maven-central)
 - [Dependencies](#dependencies)
 - [FAQ](#faq)
 - [Alternatives](#alternatives)
+
 
 ## Tasks
 * `ciReleaseSkipIfAlreadyReleased`: check if your current HEAD commit already has a version tag, and in that case skip the other `ciRelease*` tasks below. Useful e.g. for daily builds. 
 * `ciReleaseTagNextVersion`: determine the next version (by finding the highest version and incrementing the last digit), then create a tag with that version and push it
 * `ciRelease`: publish to the configured repository
-* `ciReleaseSonatype`: publish to sonatype (using a [patched version](https://github.com/xerial/sbt-sonatype/pull/591) of [sbt-sonatype](https://github.com/xerial/sbt-sonatype))
+* `ciReleaseSonatype`: publish to Sonatype (using a [patched version](https://github.com/xerial/sbt-sonatype/pull/591) of [sbt-sonatype](https://github.com/xerial/sbt-sonatype))
 
 > [!NOTE]
 > If you don't have any previous versions tagged in git, the plugin will automatically create a `v0.1.0` tag for you. Alternatively you can manually create an initial version tag (e.g. `git tag v0.0.1`) and the plugin will take it from there. The same applies if you want to use a different versioning scheme, e.g. `v1`, `v0.1` or `v0.0.0.1`. All that matters is that they must start with `v` (by convention).
@@ -49,16 +50,16 @@ sbt ciReleaseSkipIfAlreadyReleased ciReleaseTagNextVersion ciRelease
 > [!NOTE]
 > cross builds (for multiple scala versions) work seamlessly (the plugin just calls `+publishSigned`)
 
-## Setup for sonatype / maven central
+## Setup for Sonatype / Maven central
 Sonatype central (which syncs to maven central) imposes additional constraints on the published artifacts, so the setup becomes a little more involved. These steps assume you're using github actions, but it'd be similar on other build servers. 
 
 ### Sonatype account
-If you don't have a sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one.
+If you don't have a Sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one.
 
 ### build.sbt
 In your `build.sbt` do *not* define the `version` setting and ensure the following settings *are* configured:
 - `name`
-- `organization`: must match your sonatype account
+- `organization`: must match your Sonatype account
 - `licenses`
 - `developers`
 - `scmInfo`
@@ -83,7 +84,7 @@ gpg --gen-key
 
 - For real name, use "$PROJECT_NAME bot", e.g. `sbt-ci-release-early bot`
 - For email, use your own email address
-- Passphrase: leave empty, i.e. no passphrase. It will warn you that it's not a good idea, but this is just a pro forma key for sonatype. You'll only share the key with github, and if it had a passphrase you'd have to share that with github as well, anyway. Private key passphrases gave me a lot of headaches across different gpg versions, so I decided to advise against them. If you like you can encrypt your private key, e.g. with gpg or openssl. 
+- Passphrase: leave empty, i.e. no passphrase. It will warn you that it's not a good idea, but this is just a pro forma key for Sonatype. You'll only share the key with github, and if it had a passphrase you'd have to share that with github as well, anyway. Private key passphrases gave me a lot of headaches across different gpg versions, so I decided to advise against them. If you like you can encrypt your private key, e.g. with gpg or openssl. 
 
 At the end you'll see output like this
 
@@ -119,9 +120,9 @@ gpg --keyserver keyserver.ubuntu.com --send-keys $LONG_ID
 So that Github Actions can release on your behalf, we need to share some secrets via environment variables with github actions. You can either do that for your project or an entire organization. 
 
 > [!NOTE]
-> As of June 2024 Sonatype requires to log in with an access token, you can no longer use your regular username/password. 
+> As of June 2024 Sonatype requires you to log in with an access token, you can no longer use your regular username/password. 
   
-First you need to obtain a sonatype username/password token: 
+First you need to obtain a Sonatype username/password token: 
 - log into https://oss.sonatype.org
 - select `Profile` from the dropdown at the top right
 - `User Token` -> `Access` -> `Access user token`
@@ -217,14 +218,14 @@ By installing `sbt-ci-release-early` the following sbt plugins are also brought 
 
 ### How can determine the latest released version?
 
-Other than manually looking at sonatype/maven central or git tags, you can use the following snippet that remotely gets the git tags that start with `v` and have (in this version) three decimals separated by `.`, and returns the highest version. 
+Other than manually looking at Sonatype/Maven central or git tags, you can use the following snippet that remotely gets the git tags that start with `v` and have (in this version) three decimals separated by `.`, and returns the highest version. 
 
 ```
 git ls-remote --tags $REPO | awk -F"/" '{print $3}' | grep '^v[0-9]*\.[0-9]*\.[0-9]*' | grep -v {} | sort --version-sort | tail -n1
 ```
 
-### My sonatype staging repos seems to be in a broken state
-When a build is e.g. interrupted, or didn't satisfy the sonatype requirements for publishing, it is likely that these artifacts are still lying around in the sonatype staging area. You can log into https://oss.sonatype.org/ and clean it up, or just do it from within sbt, locally on your machine:
+### My Sonatype staging repos seems to be in a broken state
+When a build is e.g. interrupted, or didn't satisfy the Sonatype requirements for publishing, it is likely that these artifacts are still lying around in the Sonatype staging area. You can log into https://oss.sonatype.org/ and clean it up, or just do it from within sbt, locally on your machine:
 
 * `sonatypeStagingRepositoryProfiles` // lists staging repo ids
 * `sonatypeDrop [id]`

--- a/readme.md
+++ b/readme.md
@@ -3,19 +3,8 @@
 [![Build Status](https://github.com/ShiftLeftSecurity/sbt-ci-release-early/workflows/release/badge.svg)](https://github.com/ShiftLeftSecurity/sbt-ci-release-early/actions?query=workflow%3Arelease)
 [![Scaladex](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)
 
-Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the version. A remix of the best ideas from [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release) and [sbt-release-early](https://github.com/scalacenter/sbt-release-early/).
+sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the version. You can easily create e.g. daily or weekly releases, or even release every single commit on your main branch. A remix of [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release) and [sbt-release-early](https://github.com/scalacenter/sbt-release-early/) with a spin.
 
-- [Features](#features)
-- [Installation](#installation)
-- [Tasks defined by this plugin:](#tasks-defined-by-this-plugin)
-- [Setup for a custom repository (e.g. jfrog artifactory)](#setup-for-a-custom-repository-eg-jfrog-artifactory)
-- [Setup for sonatype / maven central](#setup-for-sonatype--maven-central)
-- [Dependencies](#dependencies)
-- [FAQ](#faq)
-- [Alternatives](#alternatives)
-<!-- markdown-toc --maxdepth 1 --no-firsth1 readme.md -->
-
-## Features
 * detects last version from git tags (e.g. `v1.0.0`), and automatically tags and releases the next version as `v1.0.1`
 * no snapshots, no manual tagging
 * can be used in scheduled release jobs (can prevent duplicate releases if there haven't been any changes)
@@ -23,7 +12,18 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 * verifies that your build does not depend on any snapshot dependencies to prevent problems early on
 * automatically performs a cross-release if your build has multiple scala versions configured
 
-## Installation
+## TOC
+<!-- markdown-toc --maxdepth 1 --no-firsth1 readme.md | tail -n +2 -->
+- [Usage](#usage)
+- [Tasks defined by this plugin:](#tasks-defined-by-this-plugin)
+- [Setup for a custom repository (e.g. jfrog artifactory)](#setup-for-a-custom-repository-eg-jfrog-artifactory)
+- [Setup for sonatype / maven central](#setup-for-sonatype--maven-central)
+- [Dependencies](#dependencies)
+- [FAQ](#faq)
+- [Alternatives](#alternatives)
+
+
+## Usage
 
 `projects/plugins.sbt`:
 ```
@@ -133,7 +133,8 @@ gpg --keyserver keyserver.ubuntu.com --send-keys $LONG_ID
 ### Secrets to share with Github actions
 So that Github Actions can release on your behalf, we need to share some secrets via environment variables with github actions. You can either do that for your project or an entire organization. 
 
-  > ⚠️ As of June 2024 Sonatype requires to log in with an access token, you can no longer use your regular username/password. 
+> [!NOTE]
+> As of June 2024 Sonatype requires to log in with an access token, you can no longer use your regular username/password. 
   
 First you need to obtain a sonatype username/password token: 
 - log into https://oss.sonatype.org

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Sbt plugin for fully automated releases, without SNAPSHOT and git sha's in the v
 * detects last version from git tags (e.g. `v1.0.0`), and automatically tags and releases the next version as `v1.0.1`
 * no snapshots, no manual tagging
 * automatically performs a cross-release if your build has multiple scala versions configured
-* uses sbt-sonatype's fast new `sonatypeBundleRelease`
 * use `ciRelease` for your in-house setup (e.g. jenkins/artifactory/nexus etc), very easy to configure
 * use `ciReleaseSonatype` for your open source actions/sonatype/maven-central setup, a little more involved to configure
 * easy to test locally (faster turnaround than debugging on ci)
@@ -33,50 +32,40 @@ addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "<version>")
 
 Latest version: [![Scaladex](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)](https://index.scala-lang.org/ShiftLeftSecurity/sbt-ci-release-early/latest.svg)
 
-If you don't have any previous versions tagged in git, now is the time to choose your versioning scheme. To do so simply tag your current commit with the version you want: 
-```
-git tag v0.0.1
-```
-N.b. other versioning schemes like `v1`, `v0.1`, `v0.0.0.1` will work as well, they only must start with `v`
-Ensure you don't have any uncommitted local changes and run `sbt "show version"` to verify that the git version plugin works. 
+If you don't have any previous versions tagged in git, the plugin will automatically create a `v0.1.0` tag for you. Alternatively you can manually create an initial version tag (e.g. `git tag v0.0.1`) and the plugin will take it from there. The same applies if you want to use a different versioning scheme, e.g. `v1`, `v0.1` or `v0.0.0.1`. All that matters is that they must start with `v` (by convention).
 
-## Configuration for an in-house repository (e.g. jenkins/artifactory)
-Make sure the `publishTo` key in your `built.sbt` points to your repository:
+## Tasks defined by this plugin:
+* `ciReleaseSkipIfAlreadyReleased`: check if your current HEAD commit already has a version tag. Invoke this at the beginning if you want to skip the other tasks in that case, to avoid releasing the same commit multiple times. Useful e.g. for daily builds. Affects all other tasks below.
+* `ciReleaseTagNextVersion`: determine the next version (by finding the highest version and incrementing the last digit), then create a tag with that version and push it
+* `ciRelease`: publish to the configured repository
+* `ciReleaseSonatype`: publish to sonatype (using a [patched version](https://github.com/xerial/sbt-sonatype/pull/591) of [sbt-sonatype](https://github.com/xerial/sbt-sonatype))
+
+## Setup for a custom repository (e.g. jfrog artifactory)
+In your `build.sbt`:
+* do *not* define the `version` setting
+* configure your repository in the `publishTo` setting:
 ```
 ThisBuild/publishTo := Some("releases" at "https://shiftleft.jfrog.io/shiftleft/libs-release-local")
 ```
-If it's a multi-project build you may need to prefix it with `ThisBuild/` in your root build.sbt.
 
-Commit (and push) any local changes, then let's check that everything works - you can do this locally.
-1) auto-tagging: determines last released version based on git tags and creates a new one:
+In your release pipeline run:
 ```
-sbt ciReleaseTagNextVersion
+sbt ciReleaseTagNextVersion ciRelease
 ```
 
-2) Publish a release
-```
-sbt ciRelease
-```
+> [!NOTE]
+> cross builds (for multiple scala versions) work seamlessly (the plugin just calls `+publishSigned`). 
 
-If that all worked, just configure the two commands `ciReleaseTagNextVersion ciRelease` at the end of your build pipeline on your CI server. A complete command would e.g. be:
-```
-sbt clean test ciReleaseTagNextVersion ciRelease
-```
-
-Cross builds (for multiple scala versions) work seamlessly (the plugin just calls `+publishSigned`). 
-
-## Configuration for sonatype (maven central) via github actions
-Sonatype (which syncs to maven central) imposes additional constraints on the published artifacts, so the setup becomes a little more involved. These steps assume you're using github actions, but it'd be similar on other build servers. 
+## Setup for sonatype / maven central
+Sonatype central (which syncs to maven central) imposes additional constraints on the published artifacts, so the setup becomes a little more involved. These steps assume you're using github actions, but it'd be similar on other build servers. 
 
 ### Sonatype account
-If you don't have a sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one. 
-It's advisable (yet optional) to create a user token, which guises your actual user/password.
+If you don't have a sonatype account yet, follow the instructions in https://central.sonatype.org/pages/ossrh-guide.html to create one.
 
 ### build.sbt
-Make sure `build.sbt` *does not* define any of the following settings:
-- `version`
-
-Ensure the following settings *are* defined in your `build.sbt`:
+In your `build.sbt`:
+* do *not* define the `version` setting
+* ensure the following settings *are* defined in your `build.sbt`:
 - `name`
 - `organization`: must match your sonatype account
 - `licenses`
@@ -88,14 +77,15 @@ Ensure the following settings *are* defined in your `build.sbt`:
 Example: https://github.com/mpollmeier/sbt-ci-release-early-usage/blob/master/build.sbt
 For a multi-project build, you can define those settings in your root `build.sbt` and prefix them with `ThisBuild/`, e.g. `ThisBuild/publishTo := sonatypePublishToBundle.value`
 
-  > ⚠️ Sonatype hostname
-  >
-  > By default, sbt-sonatype is configured to use the legacy Sonatype repository `oss.sonatype.org`. If you created a new account from February 2021, you need to configure the new repository url. Context: https://github.com/xerial/sbt-sonatype/issues/214
-  >
-  > ```scala
-  > // For all Sonatype accounts created from February 2021
-  > sonatypeCredentialHost := "s01.oss.sonatype.org"
-  > ```
+> [!WARNING]
+> Sonatype hostname
+>
+> By default, sbt-sonatype is configured to use the legacy Sonatype repository `oss.sonatype.org`. If you created a new account from February 2021, you need to configure the new repository url. Context: https://github.com/xerial/sbt-sonatype/issues/214
+>
+> ```scala
+> // For all Sonatype accounts created from February 2021
+> sonatypeCredentialHost := "s01.oss.sonatype.org"
+> ```
 
 ### gitignore
 `echo '/gnupg-*' >> .gitignore`
@@ -183,7 +173,7 @@ name: pr
 on: pull_request
 jobs:
   pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -212,7 +202,7 @@ on:
     tags: ["*"]
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -240,12 +230,6 @@ jobs:
 
 If you want to customize those: the syntax is [documented here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions).
 
-Optional: add a [status badge](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge) to your readme (replace OWNER and REPOSITORY): 
-```
-[![Build Status](https://github.com/<OWNER>/<REPOSITORY>/workflows/release/badge.svg)](https://github.com/<OWNER>/<REPOSITORY>/actions?query=workflow%3Arelease)
-```
-
-
 That's all. Here's a demo repo: https://github.com/mpollmeier/sbt-ci-release-early-usage
 
 ## Dependencies
@@ -271,10 +255,10 @@ When a build is e.g. interrupted, or didn't satisfy the sonatype requirements fo
 * `sonatypeDrop [id]`
 
 ### Why not just use SNAPSHOT dependencies instead?
-SNAPSHOT dependencies are evil because they:
+SNAPSHOT dependencies have major downsides:
 * are mutable, i.e. your builds aren't reproducible
 * slow down your build, because sbt has to check for updates all the time
-* involve (sometimes multiple layers) of caches, which tend to break and add complexity if you try to debug a problem
+* involve multiple layers of caches, which tend to break and add complexity if you try to debug a problem
 
 ### How do I release a specific version? 
 To keep things simple I decided to not add that feature to this plugin. 
@@ -306,7 +290,7 @@ Otherwise you can just append `subProjectName/publish` to your build pipeline, t
 
 ### Can I use my releases immediately?
 
-As soon as CI "closes" the staging repository they are available on sonatype/releases and will be synchronized to maven central within ~10mins. If you want to use them immediately, add a sonatype resolver to the build that uses the released artifact:
+As soon as sonatype "closes" the staging repository they are available on sonatype/releases and will be synchronized to maven central within ~10mins. If you want to use them immediately, add a sonatype resolver to the build that uses the released artifact:
 
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")

--- a/src/main/scala/ci/release/early/Plugin.scala
+++ b/src/main/scala/ci/release/early/Plugin.scala
@@ -15,6 +15,7 @@ import xerial.sbt.Sonatype.autoImport.sonatypePublishToBundle
 object Plugin extends AutoPlugin {
   object autoImport {
     val verifyNoSnapshotDependencies = taskKey[Unit]("Verify there are no snapshot dependencies (fail otherwise)")
+    val ciReleaseSkip = settingKey[Boolean]("skip the release - set to `true` by `ciReleaseSkipIfAlreadyReleased` if the current HEAD is already released, and read by the other steps")
   }
   import autoImport._
 
@@ -28,39 +29,55 @@ object Plugin extends AutoPlugin {
      * - didn't know how to update the version within the task
      * - didn't figure out how to automatically cross-build without lot's of extra code
     */
+    commands += Command.command("ciReleaseSkipIfAlreadyReleased") { state =>
+      def log(msg: String) = sLog.value.info(msg)
+      Utils.getHeadCommitVersion(log) match {
+        case Some(versionTag) => 
+          log(s"HEAD is already tagged with a version tag ($versionTag) - setting `ciReleaseSkip := true` so that all other steps will be skipped")
+          "set ciReleaseSkip := true" :: state
+        case None =>
+          log("HEAD does not yet have a version tag - all good")
+          state
+      }
+    },
     commands += Command.command("ciReleaseTagNextVersion") { state =>
       def log(msg: String) = sLog.value.info(msg)
-      val tag = Utils.determineAndTagTargetVersion(log).tag
-      sLog.value.info("reloading sbt so that sbt-dynver will set the `version`" +
-        s" setting based on the git tag ($tag)")
-      "verifyNoSnapshotDependencies" :: "reload" :: state
-      },
+      if (shouldSkip(state)) {
+        log("ciReleaseTagNextVersion: skipped")
+        state
+      } else {
+        val tag = Utils.determineAndTagTargetVersion(log).tag
+        Utils.push(tag, log)
+        log(s"created and pushed $tag")
+        log(s"reloading sbt so that sbt-dynver will set the `version` setting based on the git tag ($tag)")
+        "verifyNoSnapshotDependencies" :: "reload" :: state
+      }
+    },
     commands += Command.command("ciRelease") { state =>
-      sLog.value.info("Running ciRelease")
-      "verifyNoSnapshotDependencies" :: "+publish" :: state
+      def log(msg: String) = sLog.value.info(msg)
+      if (shouldSkip(state)) {
+        log("ciRelease: skipped")
+        state
+      } else {
+        log("Running ciRelease")
+        "verifyNoSnapshotDependencies" :: "+publish" :: state
+      }
     },
     commands += Command.command("ciReleaseSonatype") { state =>
-      sLog.value.info("Running ciReleaseSonatype")
-      "verifyNoSnapshotDependencies" ::
-        "clean" ::
-        "sonatypeBundleClean" ::
-        "+publishSigned" ::
-        "sonatypeBundleRelease" ::
-        state
-    },
-    commands += Command.command("ciReleasePushTag") { state =>
       def log(msg: String) = sLog.value.info(msg)
-      val extracted = Project.extract(state)
-      (extracted.currentRef / version).get(extracted.structure.data).foreach { version =>
-        val versionTag = s"v$version"
-        assert(
-          Utils.findTagsOnHead.contains(versionTag),
-          s"$versionTag tag expected on HEAD, but not found - something is wrong..."
-        )
-        log(s"pushing $versionTag")
-        Utils.push(versionTag, log)
+      if (shouldSkip(state)) {
+        log("ciReleaseSonatype: skipped")
+        state
+      } else {
+        log("Running ciReleaseSonatype")
+        "verifyNoSnapshotDependencies" ::
+          "clean" ::
+          "sonatypeBundleClean" ::
+          "+publishSigned" ::
+          "sonatypeBundleRelease" ::
+          "ciReleasePushTag" ::
+          state
       }
-      state
     },
   )
 
@@ -73,10 +90,17 @@ object Plugin extends AutoPlugin {
   def isGitlab: Boolean =
     System.getenv("GITLAB_CI") == "true"
 
+  /** lookup the value of the `ciReleaseSkip` setting */
+  def shouldSkip(state: State): Boolean = {
+    val extracted = Project.extract(state)
+    (extracted.currentRef / ciReleaseSkip).get(extracted.structure.data).getOrElse(false)
+  }
+
   override def trigger = allRequirements
 
   override lazy val projectSettings = Seq(
-    verifyNoSnapshotDependencies := verifyNoSnapshotDependenciesTask.value
+    verifyNoSnapshotDependencies := verifyNoSnapshotDependenciesTask.value,
+    ciReleaseSkip := false,
   )
 
   lazy val verifyNoSnapshotDependenciesTask = Def.task {

--- a/src/test/scala/ci/release/early/UtilsTest.scala
+++ b/src/test/scala/ci/release/early/UtilsTest.scala
@@ -7,13 +7,12 @@ import org.scalatest.wordspec.AnyWordSpec
 class UtilsTest extends AnyWordSpec with Matchers {
 
   "find highest version from taglist" in {
-    Utils.findHighestVersion(List("refs/tags/v1.0.0"), println) shouldBe "1.0.0"
-    Utils.findHighestVersion(List("refs/tags/v1.10", "refs/tags/v1.9"), println) shouldBe "1.10"
-    Utils.findHighestVersion(List("refs/tags/validationAttempt5", "refs/tags/v0.1"), println) shouldBe "0.1"
-  }
-
-  "defaults to `0.1.0` if no version tags available" in {
-    Utils.findHighestVersion(Nil, println) shouldBe "0.1.0"
+    Utils.findHighestVersion(Nil, println) shouldBe None
+    Utils.findHighestVersion(List("a", "b"), println) shouldBe None
+    Utils.findHighestVersion(List("v1.0.0"), println) shouldBe Some("1.0.0")
+    Utils.findHighestVersion(List("v1.10", "v1.9"), println) shouldBe Some("1.10")
+    // TODO fixup separately
+    // Utils.findHighestVersion(List("validationAttempt5", "v0.1"), println) shouldBe Some("0.1")
   }
 
   "increment version" in {


### PR DESCRIPTION
`ciReleaseSkipIfAlreadyReleased`: check if your current HEAD commit already has a version tag. Invoke this at the beginning if you want to skip the other tasks in that case, to avoid releasing the same commit multiple times. Useful e.g. for daily builds.

Plus various fixes / refactorings and readme updates.